### PR TITLE
Update module paths to point to this fork

### DIFF
--- a/cmd/analyze.go
+++ b/cmd/analyze.go
@@ -8,8 +8,8 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	"github.com/wagoodman/dive/dive"
-	"github.com/wagoodman/dive/runtime"
+	"github.com/jauderho/dive/dive"
+	"github.com/jauderho/dive/runtime"
 )
 
 // doAnalyzeCmd takes a docker image tag, digest, or id and displays the

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -4,8 +4,8 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	"github.com/wagoodman/dive/dive"
-	"github.com/wagoodman/dive/runtime"
+	"github.com/jauderho/dive/dive"
+	"github.com/jauderho/dive/runtime"
 )
 
 // buildCmd represents the build command

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,8 +12,8 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	"github.com/wagoodman/dive/dive"
-	"github.com/wagoodman/dive/dive/filetree"
+	"github.com/jauderho/dive/dive"
+	"github.com/jauderho/dive/dive/filetree"
 )
 
 var cfgFile string

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -2,17 +2,10 @@ package cmd
 
 import (
 	"fmt"
+	"runtime/debug"
 
 	"github.com/spf13/cobra"
 )
-
-type Version struct {
-	Version   string
-	Commit    string
-	BuildTime string
-}
-
-var version *Version
 
 // versionCmd represents the version command
 var versionCmd = &cobra.Command{
@@ -25,10 +18,12 @@ func init() {
 	rootCmd.AddCommand(versionCmd)
 }
 
-func SetVersion(v *Version) {
-	version = v
-}
-
 func printVersion(cmd *cobra.Command, args []string) {
-	fmt.Printf("dive %s\n", version.Version)
+	var bi, ok = debug.ReadBuildInfo()
+	if ok {
+		fmt.Printf("dive %s from %s\n", bi.Main.Version, bi.Main.Path)
+	} else {
+		fmt.Printf("dive (unknown version)")
+	}
+
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -2,10 +2,17 @@ package cmd
 
 import (
 	"fmt"
-	"runtime/debug"
 
 	"github.com/spf13/cobra"
 )
+
+type Version struct {
+	Version   string
+	Commit    string
+	BuildTime string
+}
+
+var version *Version
 
 // versionCmd represents the version command
 var versionCmd = &cobra.Command{
@@ -18,12 +25,10 @@ func init() {
 	rootCmd.AddCommand(versionCmd)
 }
 
-func printVersion(cmd *cobra.Command, args []string) {
-	var bi, ok = debug.ReadBuildInfo()
-	if ok {
-		fmt.Printf("dive %s from %s\n", bi.Main.Version, bi.Main.Path)
-	} else {
-		fmt.Printf("dive (unknown version)")
-	}
+func SetVersion(v *Version) {
+	version = v
+}
 
+func printVersion(cmd *cobra.Command, args []string) {
+	fmt.Printf("dive %s\n", version.Version)
 }

--- a/dive/get_image_resolver.go
+++ b/dive/get_image_resolver.go
@@ -5,9 +5,9 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/wagoodman/dive/dive/image"
-	"github.com/wagoodman/dive/dive/image/docker"
-	"github.com/wagoodman/dive/dive/image/podman"
+	"github.com/jauderho/dive/dive/image"
+	"github.com/jauderho/dive/dive/image/docker"
+	"github.com/jauderho/dive/dive/image/podman"
 )
 
 const (

--- a/dive/image/analyzer.go
+++ b/dive/image/analyzer.go
@@ -1,7 +1,7 @@
 package image
 
 import (
-	"github.com/wagoodman/dive/dive/filetree"
+	"github.com/jauderho/dive/dive/filetree"
 )
 
 type Analyzer interface {

--- a/dive/image/docker/archive_resolver.go
+++ b/dive/image/docker/archive_resolver.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/wagoodman/dive/dive/image"
+	"github.com/jauderho/dive/dive/image"
 )
 
 type archiveResolver struct{}

--- a/dive/image/docker/cli.go
+++ b/dive/image/docker/cli.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"os/exec"
 
-	"github.com/wagoodman/dive/utils"
+	"github.com/jauderho/dive/utils"
 )
 
 // runDockerCmd runs a given Docker command in the current tty

--- a/dive/image/docker/engine_resolver.go
+++ b/dive/image/docker/engine_resolver.go
@@ -11,7 +11,7 @@ import (
 	"github.com/docker/docker/client"
 	"golang.org/x/net/context"
 
-	"github.com/wagoodman/dive/dive/image"
+	"github.com/jauderho/dive/dive/image"
 )
 
 type engineResolver struct{}

--- a/dive/image/docker/image_archive.go
+++ b/dive/image/docker/image_archive.go
@@ -11,8 +11,8 @@ import (
 	"path"
 	"strings"
 
-	"github.com/wagoodman/dive/dive/filetree"
-	"github.com/wagoodman/dive/dive/image"
+	"github.com/jauderho/dive/dive/filetree"
+	"github.com/jauderho/dive/dive/image"
 )
 
 type ImageArchive struct {

--- a/dive/image/docker/layer.go
+++ b/dive/image/docker/layer.go
@@ -3,8 +3,8 @@ package docker
 import (
 	"strings"
 
-	"github.com/wagoodman/dive/dive/filetree"
-	"github.com/wagoodman/dive/dive/image"
+	"github.com/jauderho/dive/dive/filetree"
+	"github.com/jauderho/dive/dive/image"
 )
 
 // Layer represents a Docker image layer and metadata

--- a/dive/image/docker/testing.go
+++ b/dive/image/docker/testing.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/wagoodman/dive/dive/image"
+	"github.com/jauderho/dive/dive/image"
 )
 
 func TestLoadArchive(tarPath string) (*ImageArchive, error) {

--- a/dive/image/image.go
+++ b/dive/image/image.go
@@ -1,7 +1,7 @@
 package image
 
 import (
-	"github.com/wagoodman/dive/dive/filetree"
+	"github.com/jauderho/dive/dive/filetree"
 )
 
 type Image struct {

--- a/dive/image/layer.go
+++ b/dive/image/layer.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/dustin/go-humanize"
 
-	"github.com/wagoodman/dive/dive/filetree"
+	"github.com/jauderho/dive/dive/filetree"
 )
 
 const (

--- a/dive/image/podman/cli.go
+++ b/dive/image/podman/cli.go
@@ -9,7 +9,7 @@ import (
 	"os"
 	"os/exec"
 
-	"github.com/wagoodman/dive/utils"
+	"github.com/jauderho/dive/utils"
 )
 
 // runPodmanCmd runs a given Podman command in the current tty

--- a/dive/image/podman/resolver.go
+++ b/dive/image/podman/resolver.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/wagoodman/dive/dive/image"
-	"github.com/wagoodman/dive/dive/image/docker"
+	"github.com/jauderho/dive/dive/image"
+	"github.com/jauderho/dive/dive/image/docker"
 )
 
 type resolver struct{}

--- a/dive/image/podman/resolver_unsupported.go
+++ b/dive/image/podman/resolver_unsupported.go
@@ -6,7 +6,7 @@ package podman
 import (
 	"fmt"
 
-	"github.com/wagoodman/dive/dive/image"
+	"github.com/jauderho/dive/dive/image"
 )
 
 type resolver struct{}

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/wagoodman/dive
+module github.com/jauderho/dive
 
 go 1.22.0
 

--- a/main.go
+++ b/main.go
@@ -21,21 +21,9 @@
 package main
 
 import (
-	"github.com/wagoodman/dive/cmd"
-)
-
-var (
-	version   = "No version provided"
-	commit    = "No commit provided"
-	buildTime = "No build timestamp provided"
+	"github.com/jauderho/dive/cmd"
 )
 
 func main() {
-	cmd.SetVersion(&cmd.Version{
-		Version:   version,
-		Commit:    commit,
-		BuildTime: buildTime,
-	})
-
 	cmd.Execute()
 }

--- a/runtime/ci/evaluator.go
+++ b/runtime/ci/evaluator.go
@@ -10,8 +10,8 @@ import (
 	"github.com/logrusorgru/aurora"
 	"github.com/spf13/viper"
 
-	"github.com/wagoodman/dive/dive/image"
-	"github.com/wagoodman/dive/utils"
+	"github.com/jauderho/dive/dive/image"
+	"github.com/jauderho/dive/utils"
 )
 
 type CiEvaluator struct {

--- a/runtime/ci/evaluator_test.go
+++ b/runtime/ci/evaluator_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/spf13/viper"
 
-	"github.com/wagoodman/dive/dive/image/docker"
+	"github.com/jauderho/dive/dive/image/docker"
 )
 
 func Test_Evaluator(t *testing.T) {

--- a/runtime/ci/rule.go
+++ b/runtime/ci/rule.go
@@ -8,7 +8,7 @@ import (
 	"github.com/logrusorgru/aurora"
 	"github.com/spf13/viper"
 
-	"github.com/wagoodman/dive/dive/image"
+	"github.com/jauderho/dive/dive/image"
 )
 
 const (

--- a/runtime/export/export.go
+++ b/runtime/export/export.go
@@ -3,7 +3,7 @@ package export
 import (
 	"encoding/json"
 
-	diveImage "github.com/wagoodman/dive/dive/image"
+	diveImage "github.com/jauderho/dive/dive/image"
 )
 
 type export struct {

--- a/runtime/export/export_test.go
+++ b/runtime/export/export_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/sergi/go-diff/diffmatchpatch"
 
-	"github.com/wagoodman/dive/dive/image/docker"
+	"github.com/jauderho/dive/dive/image/docker"
 )
 
 func Test_Export(t *testing.T) {

--- a/runtime/options.go
+++ b/runtime/options.go
@@ -3,7 +3,7 @@ package runtime
 import (
 	"github.com/spf13/viper"
 
-	"github.com/wagoodman/dive/dive"
+	"github.com/jauderho/dive/dive"
 )
 
 type Options struct {

--- a/runtime/run.go
+++ b/runtime/run.go
@@ -9,13 +9,13 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
 
-	"github.com/wagoodman/dive/dive"
-	"github.com/wagoodman/dive/dive/filetree"
-	"github.com/wagoodman/dive/dive/image"
-	"github.com/wagoodman/dive/runtime/ci"
-	"github.com/wagoodman/dive/runtime/export"
-	"github.com/wagoodman/dive/runtime/ui"
-	"github.com/wagoodman/dive/utils"
+	"github.com/jauderho/dive/dive"
+	"github.com/jauderho/dive/dive/filetree"
+	"github.com/jauderho/dive/dive/image"
+	"github.com/jauderho/dive/runtime/ci"
+	"github.com/jauderho/dive/runtime/export"
+	"github.com/jauderho/dive/runtime/ui"
+	"github.com/jauderho/dive/utils"
 )
 
 func run(enableUi bool, options Options, imageResolver image.Resolver, events eventChannel, filesystem afero.Fs) {

--- a/runtime/run_test.go
+++ b/runtime/run_test.go
@@ -9,9 +9,9 @@ import (
 	"github.com/spf13/afero"
 	"github.com/spf13/viper"
 
-	"github.com/wagoodman/dive/dive"
-	"github.com/wagoodman/dive/dive/image"
-	"github.com/wagoodman/dive/dive/image/docker"
+	"github.com/jauderho/dive/dive"
+	"github.com/jauderho/dive/dive/image"
+	"github.com/jauderho/dive/dive/image/docker"
 )
 
 type defaultResolver struct{}

--- a/runtime/ui/app.go
+++ b/runtime/ui/app.go
@@ -6,11 +6,11 @@ import (
 	"github.com/awesome-gocui/gocui"
 	"github.com/sirupsen/logrus"
 
-	"github.com/wagoodman/dive/dive/filetree"
-	"github.com/wagoodman/dive/dive/image"
-	"github.com/wagoodman/dive/runtime/ui/key"
-	"github.com/wagoodman/dive/runtime/ui/layout"
-	"github.com/wagoodman/dive/runtime/ui/layout/compound"
+	"github.com/jauderho/dive/dive/filetree"
+	"github.com/jauderho/dive/dive/image"
+	"github.com/jauderho/dive/runtime/ui/key"
+	"github.com/jauderho/dive/runtime/ui/layout"
+	"github.com/jauderho/dive/runtime/ui/layout/compound"
 )
 
 const debug = false

--- a/runtime/ui/controller.go
+++ b/runtime/ui/controller.go
@@ -6,10 +6,10 @@ import (
 	"github.com/awesome-gocui/gocui"
 	"github.com/sirupsen/logrus"
 
-	"github.com/wagoodman/dive/dive/filetree"
-	"github.com/wagoodman/dive/dive/image"
-	"github.com/wagoodman/dive/runtime/ui/view"
-	"github.com/wagoodman/dive/runtime/ui/viewmodel"
+	"github.com/jauderho/dive/dive/filetree"
+	"github.com/jauderho/dive/dive/image"
+	"github.com/jauderho/dive/runtime/ui/view"
+	"github.com/jauderho/dive/runtime/ui/viewmodel"
 )
 
 type Controller struct {

--- a/runtime/ui/key/binding.go
+++ b/runtime/ui/key/binding.go
@@ -8,7 +8,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 
-	"github.com/wagoodman/dive/runtime/ui/format"
+	"github.com/jauderho/dive/runtime/ui/format"
 )
 
 type BindingInfo struct {

--- a/runtime/ui/layout/compound/layer_details_column.go
+++ b/runtime/ui/layout/compound/layer_details_column.go
@@ -4,8 +4,8 @@ import (
 	"github.com/awesome-gocui/gocui"
 	"github.com/sirupsen/logrus"
 
-	"github.com/wagoodman/dive/runtime/ui/view"
-	"github.com/wagoodman/dive/utils"
+	"github.com/jauderho/dive/runtime/ui/view"
+	"github.com/jauderho/dive/utils"
 )
 
 type LayerDetailsCompoundLayout struct {

--- a/runtime/ui/view/debug.go
+++ b/runtime/ui/view/debug.go
@@ -6,8 +6,8 @@ import (
 	"github.com/awesome-gocui/gocui"
 	"github.com/sirupsen/logrus"
 
-	"github.com/wagoodman/dive/runtime/ui/format"
-	"github.com/wagoodman/dive/utils"
+	"github.com/jauderho/dive/runtime/ui/format"
+	"github.com/jauderho/dive/utils"
 )
 
 // Debug is just for me :)

--- a/runtime/ui/view/filetree.go
+++ b/runtime/ui/view/filetree.go
@@ -8,11 +8,11 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 
-	"github.com/wagoodman/dive/dive/filetree"
-	"github.com/wagoodman/dive/runtime/ui/format"
-	"github.com/wagoodman/dive/runtime/ui/key"
-	"github.com/wagoodman/dive/runtime/ui/viewmodel"
-	"github.com/wagoodman/dive/utils"
+	"github.com/jauderho/dive/dive/filetree"
+	"github.com/jauderho/dive/runtime/ui/format"
+	"github.com/jauderho/dive/runtime/ui/key"
+	"github.com/jauderho/dive/runtime/ui/viewmodel"
+	"github.com/jauderho/dive/utils"
 )
 
 type ViewOptionChangeListener func() error

--- a/runtime/ui/view/filter.go
+++ b/runtime/ui/view/filter.go
@@ -7,8 +7,8 @@ import (
 	"github.com/awesome-gocui/gocui"
 	"github.com/sirupsen/logrus"
 
-	"github.com/wagoodman/dive/runtime/ui/format"
-	"github.com/wagoodman/dive/utils"
+	"github.com/jauderho/dive/runtime/ui/format"
+	"github.com/jauderho/dive/utils"
 )
 
 type FilterEditListener func(string) error

--- a/runtime/ui/view/image_details.go
+++ b/runtime/ui/view/image_details.go
@@ -9,9 +9,9 @@ import (
 	"github.com/dustin/go-humanize"
 	"github.com/sirupsen/logrus"
 
-	"github.com/wagoodman/dive/dive/filetree"
-	"github.com/wagoodman/dive/runtime/ui/format"
-	"github.com/wagoodman/dive/runtime/ui/key"
+	"github.com/jauderho/dive/dive/filetree"
+	"github.com/jauderho/dive/runtime/ui/format"
+	"github.com/jauderho/dive/runtime/ui/key"
 )
 
 type ImageDetails struct {

--- a/runtime/ui/view/layer.go
+++ b/runtime/ui/view/layer.go
@@ -7,10 +7,10 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 
-	"github.com/wagoodman/dive/dive/image"
-	"github.com/wagoodman/dive/runtime/ui/format"
-	"github.com/wagoodman/dive/runtime/ui/key"
-	"github.com/wagoodman/dive/runtime/ui/viewmodel"
+	"github.com/jauderho/dive/dive/image"
+	"github.com/jauderho/dive/runtime/ui/format"
+	"github.com/jauderho/dive/runtime/ui/key"
+	"github.com/jauderho/dive/runtime/ui/viewmodel"
 )
 
 // Layer holds the UI objects and data models for populating the lower-left pane.

--- a/runtime/ui/view/layer_change_listener.go
+++ b/runtime/ui/view/layer_change_listener.go
@@ -1,5 +1,5 @@
 package view
 
-import "github.com/wagoodman/dive/runtime/ui/viewmodel"
+import "github.com/jauderho/dive/runtime/ui/viewmodel"
 
 type LayerChangeListener func(viewmodel.LayerSelection) error

--- a/runtime/ui/view/layer_details.go
+++ b/runtime/ui/view/layer_details.go
@@ -7,9 +7,9 @@ import (
 	"github.com/awesome-gocui/gocui"
 	"github.com/sirupsen/logrus"
 
-	"github.com/wagoodman/dive/dive/image"
-	"github.com/wagoodman/dive/runtime/ui/format"
-	"github.com/wagoodman/dive/runtime/ui/key"
+	"github.com/jauderho/dive/dive/image"
+	"github.com/jauderho/dive/runtime/ui/format"
+	"github.com/jauderho/dive/runtime/ui/key"
 )
 
 type LayerDetails struct {

--- a/runtime/ui/view/status.go
+++ b/runtime/ui/view/status.go
@@ -7,9 +7,9 @@ import (
 	"github.com/awesome-gocui/gocui"
 	"github.com/sirupsen/logrus"
 
-	"github.com/wagoodman/dive/runtime/ui/format"
-	"github.com/wagoodman/dive/runtime/ui/key"
-	"github.com/wagoodman/dive/utils"
+	"github.com/jauderho/dive/runtime/ui/format"
+	"github.com/jauderho/dive/runtime/ui/key"
+	"github.com/jauderho/dive/utils"
 )
 
 // Status holds the UI objects and data models for populating the bottom-most pane. Specifically the panel

--- a/runtime/ui/view/views.go
+++ b/runtime/ui/view/views.go
@@ -3,8 +3,8 @@ package view
 import (
 	"github.com/awesome-gocui/gocui"
 
-	"github.com/wagoodman/dive/dive/filetree"
-	"github.com/wagoodman/dive/dive/image"
+	"github.com/jauderho/dive/dive/filetree"
+	"github.com/jauderho/dive/dive/image"
 )
 
 type IView interface {

--- a/runtime/ui/viewmodel/filetree.go
+++ b/runtime/ui/viewmodel/filetree.go
@@ -10,8 +10,8 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 
-	"github.com/wagoodman/dive/dive/filetree"
-	"github.com/wagoodman/dive/runtime/ui/format"
+	"github.com/jauderho/dive/dive/filetree"
+	"github.com/jauderho/dive/runtime/ui/format"
 )
 
 // FileTreeViewModel holds the UI objects and data models for populating the right pane. Specifically the pane that

--- a/runtime/ui/viewmodel/filetree_test.go
+++ b/runtime/ui/viewmodel/filetree_test.go
@@ -10,9 +10,9 @@ import (
 	"github.com/fatih/color"
 	"github.com/sergi/go-diff/diffmatchpatch"
 
-	"github.com/wagoodman/dive/dive/filetree"
-	"github.com/wagoodman/dive/dive/image/docker"
-	"github.com/wagoodman/dive/runtime/ui/format"
+	"github.com/jauderho/dive/dive/filetree"
+	"github.com/jauderho/dive/dive/image/docker"
+	"github.com/jauderho/dive/runtime/ui/format"
 )
 
 const allowTestDataCapture = false

--- a/runtime/ui/viewmodel/layer_selection.go
+++ b/runtime/ui/viewmodel/layer_selection.go
@@ -1,7 +1,7 @@
 package viewmodel
 
 import (
-	"github.com/wagoodman/dive/dive/image"
+	"github.com/jauderho/dive/dive/image"
 )
 
 type LayerSelection struct {

--- a/runtime/ui/viewmodel/layer_set_state.go
+++ b/runtime/ui/viewmodel/layer_set_state.go
@@ -1,6 +1,6 @@
 package viewmodel
 
-import "github.com/wagoodman/dive/dive/image"
+import "github.com/jauderho/dive/dive/image"
 
 type LayerSetState struct {
 	LayerIndex        int


### PR DESCRIPTION
This changes the module paths in files to point to this specific fork of `dive`. This is mainly for neatness and the version code in #158 - which should make it clear that people are using a 'different' version of dive, which might become important in the future for bug reports